### PR TITLE
Use common lisp function

### DIFF
--- a/company-reftex.el
+++ b/company-reftex.el
@@ -38,14 +38,13 @@
 
 
 (eval-when-compile
-  (require 'cl-lib)
   (require 'rx))
 
+(require 'cl-lib)
 (require 'company)
 (require 'reftex)
 (require 'reftex-cite)
 (require 's)
-
 
 
 ;; Customization
@@ -164,7 +163,7 @@ For more information on COMMAND and ARG see `company-backends'."
   (cl-loop for entry in (symbol-value reftex-docstruct-symbol)
            if (and (stringp (car entry)) (string-prefix-p prefix (car entry)))
            collect
-           (company-reftex-annotate (car entry) (caddr entry))))
+           (company-reftex-annotate (car entry) (cl-caddr entry))))
 
 ;;;###autoload
 (defun company-reftex-labels (command &optional arg &rest _)


### PR DESCRIPTION
`caddr` is not a Elisp function, which leads to the error

> Company: backend company-reftex-labels error "Symbol’s function definition is void: caddr" with args"

Changing to `cl-caddr` fixes this error.