### PR TITLE
Provide all bibliography candidates in case of empty regular expression + minor bugfix

### DIFF
--- a/company-reftex.el
+++ b/company-reftex.el
@@ -180,7 +180,9 @@ Obeys the setting of `company-reftex-max-annotation-length'."
   ;; Reftex will ask for a regexp by using `completing-read'
   ;; Override this programatically with a regexp from the prefix
   (cl-letf (((symbol-function 'reftex--query-search-regexps)
-             (lambda (_) (list (regexp-quote prefix)))))
+             (lambda (_) (if (string= prefix "")
+                             (list ".+")
+                           (list (regexp-quote prefix))))))
     (let* ((bibtype (reftex-bib-or-thebib))
            (candidates
             (cond

--- a/company-reftex.el
+++ b/company-reftex.el
@@ -209,7 +209,7 @@ Obeys the setting of `company-reftex-max-annotation-length'."
 For more information on COMMAND and ARG see `company-backends'."
   (interactive (list 'interactive))
   (cl-case command
-    (interactive (company-begin-backend 'company-reftex-labels))
+    (interactive (company-begin-backend 'company-reftex-citations))
     (prefix (company-reftex-prefix company-reftex-citations-regexp))
     (candidates (company-reftex-citation-candidates arg))
     (annotation (when company-reftex-annotate-citations


### PR DESCRIPTION
This PR addresses #7, with the following commit-summary:

1. 5b19c6956aec9efa3cc411cd755784d061a409a6: Fix `company-reftex-citations` to have the same backend name under `company-begin-backend`.

2. 43f6e29e81215ba474edc4dd90918f783650bfb1: New feature whereby an empty regular expression allows for a match of all bibliography candidates. Previous behaviour would return no candidates if completion is requested on eg. `\cite{`. New behaviour would provide all candidates when completion is requested on eg. `\cite{`.

2. Contd. Substitution of an empty regular expression with `.+` is necessary and preferred over `.*`, since the latter would lead to a long runtime which causes `reftex` to hang.

I tested this implementation on my local `emacs` install and it works wonderfully. WDYT?