### PR TITLE
Call reftex-parse-all before searching for labels

### DIFF
--- a/company-reftex.el
+++ b/company-reftex.el
@@ -226,6 +226,7 @@ For more information on COMMAND and ARG see `company-backends'."
 (defun company-reftex-label-candidates (prefix)
   "Find all label candidates matching PREFIX."
   (reftex-access-scan-info)
+  (reftex-parse-all)
   (cl-loop for entry in (symbol-value reftex-docstruct-symbol)
            if (and (stringp (car entry)) (string-prefix-p prefix (car entry)))
            collect


### PR DESCRIPTION
This PR addresses issue #11 by calling `(reftex-parse-all)` before searching for label candidates. This ensures that reftex parses all new labels and loads them before searching using the input prefix.

PS: Based on my tests, it does not cause a performance sink. Feel free to test it as well.