### PR TITLE
Add option to disable `reftex-parse-all`

### DIFF
--- a/company-reftex.el
+++ b/company-reftex.el
@@ -71,6 +71,11 @@ See `reftex-format-citation'."
   :type '(choice (const :tag "Off" nil) integer)
   :group 'company-reftex)
 
+(defcustom company-reftex-labels-parse-all t
+  "Whether to rescan labels in entire document."
+  :type 'boolean
+  :group 'company-reftex)
+
 (defcustom company-reftex-labels-regexp
   (rx "\\"
       ;; List taken from `reftex-ref-style-alist'
@@ -225,8 +230,9 @@ For more information on COMMAND and ARG see `company-backends'."
 
 (defun company-reftex-label-candidates (prefix)
   "Find all label candidates matching PREFIX."
-  (reftex-access-scan-info)
-  (reftex-parse-all)
+  (if company-reftex-labels-parse-all
+      (reftex-parse-all)
+    (reftex-parse-one))
   (cl-loop for entry in (symbol-value reftex-docstruct-symbol)
            if (and (stringp (car entry)) (string-prefix-p prefix (car entry)))
            collect


### PR DESCRIPTION
## Overview

This PR addresses #11 by adding an option to disable the call to `reftex-parse-all`, which could be the cause of the performance sink reported.

## Tasks before merge

- [x] Check if this PR addresses the performance issues reported in #11 
- [ ] Check if the optimizations [here](https://www.gnu.org/software/auctex/manual/reftex/Optimizations.html) further improve performance. If so, we could add this link to our readme so other users could add these to their emacs configuration